### PR TITLE
Add latest tag to docker image.

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -65,3 +65,13 @@ jobs:
       run: |
         echo "${DOCKER_HUB_TOKEN}" | docker login -u optunabot --password-stdin
         docker push "${HUB_TAG}"
+
+    # Assume python_version is only 3.12.
+    - name: Tag and Push latest image
+      if: ${{ github.event_name == 'release' }}
+      env:
+        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+      run: |
+        echo "${DOCKER_HUB_TOKEN}" | docker login -u optunabot --password-stdin
+        docker tag "${HUB_TAG}" "${DOCKER_HUB_BASE_NAME}:latest"
+        docker push "${DOCKER_HUB_BASE_NAME}:latest"


### PR DESCRIPTION
## Motivation

This pull request updates the Docker image workflow to include tagging and pushing the latest image when a release event is triggered.

## Description of the changes

- Add "Tag and Push latest image" step.