### PR TITLE
Remove Python version from Docker tag names to be published

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,9 +1,6 @@
 name: Build Docker Image
 
 on:
-  push:
-    branches:
-      - main
   release:
     types: [published]
   pull_request:
@@ -19,16 +16,13 @@ concurrency:
 
 env:
   DOCKER_HUB_BASE_NAME: optuna/optuna-mcp
+  PYTHON_VERSION: '3.12'
 
 jobs:
 
   dockerimage:
 
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        python_version: ['3.12']
 
     # This action cannot be executed in the forked repository.
     if: github.repository == 'optuna/optuna-mcp'
@@ -37,9 +31,9 @@ jobs:
 
     - name: Set ENV
       run: |
-        export TAG_NAME="py${{ matrix.python_version }}"
+        export TAG_NAME="py${PYTHON_VERSION}"
         if [ "${{ github.event_name }}" = 'release' ]; then
-          export TAG_NAME="${{ github.event.release.tag_name }}-${TAG_NAME}"
+          export TAG_NAME="${{ github.event.release.tag_name }}"
         fi
         echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> $GITHUB_ENV
 
@@ -50,7 +44,7 @@ jobs:
         else
           CACHE_FROM="--cache-from=${HUB_TAG}"
         fi
-        docker build ${CACHE_FROM} . --build-arg PYTHON_VERSION=${{ matrix.python_version }} --file Dockerfile --tag "${HUB_TAG}"
+        docker build ${CACHE_FROM} . --build-arg PYTHON_VERSION=${PYTHON_VERSION} --file Dockerfile --tag "${HUB_TAG}"
       env:
         DOCKER_BUILDKIT: 1
 
@@ -59,19 +53,11 @@ jobs:
         docker run "${HUB_TAG}" optuna-mcp -h
 
     - name: Login & Push to Docker Hub
-      if: ${{ github.event_name != 'pull_request' }}
-      env:
-        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-      run: |
-        echo "${DOCKER_HUB_TOKEN}" | docker login -u optunabot --password-stdin
-        docker push "${HUB_TAG}"
-
-    # Assume python_version is only 3.12.
-    - name: Tag and Push latest image
       if: ${{ github.event_name == 'release' }}
       env:
         DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
       run: |
         echo "${DOCKER_HUB_TOKEN}" | docker login -u optunabot --password-stdin
+        docker push "${HUB_TAG}"
         docker tag "${HUB_TAG}" "${DOCKER_HUB_BASE_NAME}:latest"
         docker push "${DOCKER_HUB_BASE_NAME}:latest"


### PR DESCRIPTION
## Motivation

This pull request simplifies and refines the Docker image build workflow by removing unnecessary configurations, consolidating Python version handling, and adjusting the Docker push logic. The changes aim to streamline the workflow and improve maintainability.

The Docker tags to be released will be changed as follows:

Current `main`:
- master push trigger: `py3.12` 
- release trigger: `v0.1.0-py3.12` and `latest`

This PR:
- master push trigger: None
- release trigger: `v0.1.0` and `latest`

## Description of the changes

### Workflow simplification
* Removed the `push` trigger for the `main` branch, leaving only the `release` and `pull_request` triggers active to focus on relevant events
* Eliminated the `matrix` strategy for Python versions, hardcoding the `PYTHON_VERSION` as an environment variable instead. This simplifies the workflow since only Python 3.12 is supported

### Change docker tags

* Updated the Docker build command to use the new `PYTHON_VERSION` environment variable instead of the matrix variable, ensuring consistency and reducing complexity 
* Refined the Docker Hub push logic by removing redundant conditions and assuming a single Python version.