### PR TITLE
Use `docker/build-push-action` to support multi-platform build.

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -34,7 +34,7 @@ jobs:
         if [ "${{ github.event_name }}" = 'release' ]; then
           export TAG_NAME="${{ github.event.release.tag_name }}"
         fi
-        echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> $GITHUB_ENV
+        echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
 
     - name: Login to Docker Hub
       if: ${{ github.event_name == 'release' }}
@@ -56,5 +56,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name == 'release' }}
         tags: |
-          "${HUB_TAG}"
-          "${DOCKER_HUB_BASE_NAME}:latest"
+          ${{ env.DOCKER_HUB_BASE_NAME }}:${{ env.TAG_NAME }}
+          ${{ env.DOCKER_HUB_BASE_NAME }}:latest

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   DOCKER_HUB_BASE_NAME: optuna/optuna-mcp
-  PYTHON_VERSION: '3.12'
 
 jobs:
 
@@ -31,33 +30,31 @@ jobs:
 
     - name: Set ENV
       run: |
-        export TAG_NAME="py${PYTHON_VERSION}"
+        export TAG_NAME="ci"
         if [ "${{ github.event_name }}" = 'release' ]; then
           export TAG_NAME="${{ github.event.release.tag_name }}"
         fi
         echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> $GITHUB_ENV
 
-    - name: Build the Docker image
-      run: |
-        if [ "${{ github.event_name }}" = 'release' ]; then
-          CACHE_FROM=""
-        else
-          CACHE_FROM="--cache-from=${HUB_TAG}"
-        fi
-        docker build ${CACHE_FROM} . --build-arg PYTHON_VERSION=${PYTHON_VERSION} --file Dockerfile --tag "${HUB_TAG}"
-      env:
-        DOCKER_BUILDKIT: 1
-
-    - name: Verify the built image
-      run: |
-        docker run "${HUB_TAG}" optuna-mcp -h
-
-    - name: Login & Push to Docker Hub
+    - name: Login to Docker Hub
       if: ${{ github.event_name == 'release' }}
-      env:
-        DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-      run: |
-        echo "${DOCKER_HUB_TOKEN}" | docker login -u optunabot --password-stdin
-        docker push "${HUB_TAG}"
-        docker tag "${HUB_TAG}" "${DOCKER_HUB_BASE_NAME}:latest"
-        docker push "${DOCKER_HUB_BASE_NAME}:latest"
+      uses: docker/login-action@v3
+      with:
+        username: optunabot
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name == 'release' }}
+        tags: |
+          "${HUB_TAG}"
+          "${DOCKER_HUB_BASE_NAME}:latest"


### PR DESCRIPTION
## Motivation

This pull request updates the Docker image build workflow in `.github/workflows/dockerimage.yml` to modernize the setup and improve maintainability. The key changes include replacing custom scripting with standardized Docker GitHub Actions (see https://github.com/docker/build-push-action) and simplifying the handling of environment variables.

This PR will change Docker tags as follows:

Current main:
- pull request trigger: **`py3.12`** will be created, but not pushed
- release trigger: `v0.1.1` and `latest` will be pushed (unchanged)

This PR:
- pull request trigger: **`ci`** will be created but not pushed
- release trigger: `v0.1.1` and `latest` will be pushed (unchanged)

Removing the Python version will simplify the CI configuration.

## Description of the changes

* Replaced manual Docker login, QEMU setup, and Buildx setup steps with standardized GitHub Actions.
* Replaced the custom Docker build and push script with `docker/build-push-action@v6`, which supports multi-platform builds and integrates seamlessly with GitHub Actions.
* Removed `PYTHON_VERSION` from the environment variables and updated the `TAG_NAME` logic to use a static "ci" tag for non-release events.