### PR TITLE
Run tests with 3.13.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,20 +11,16 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
         with:
             version: "latest"
+            python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Motivation

This pull request updates the GitHub Actions workflow configuration in `.github/workflows/tests.yml` to enhance compatibility and use the latest tools. The most important changes include adding support for Python 3.13 and upgrading the `setup-uv` action to version 5. This PR used `setup-uv` to specify Python version according to https://docs.astral.sh/uv/guides/integration/github/.

## Description of the changes

* Added Python 3.13 to the matrix of supported Python versions.
* Upgraded the `setup-uv` action from version 3 to version 5 and included the `python-version` parameter to ensure compatibility with the matrix configuration.
