### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that automates optimization and analysis using [Optuna](http://optuna.org).
 
+<a href="https://glama.ai/mcp/servers/@optuna/optuna-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@optuna/optuna-mcp/badge" alt="Optuna Server MCP server" />
+</a>
+
 <img width="840" alt="image" src="https://raw.githubusercontent.com/optuna/optuna-mcp/main/examples/sphere2d/images/sphere2d-6.png" />
 
 ## Use Cases
@@ -242,4 +246,3 @@ Check out [examples/auto-matplotlib](https://github.com/optuna/optuna-mcp/tree/m
 ## License
 
 MIT License (see [LICENSE](./LICENSE)).
-


### PR DESCRIPTION
This PR adds a badge for the [Optuna MCP Server](https://glama.ai/mcp/servers/@optuna/optuna-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@optuna/optuna-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@optuna/optuna-mcp/badge" alt="Optuna Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.