### PR TITLE
Update latest image periodically.

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,7 +10,7 @@ on:
       - Dockerfile
       - pyproject.toml
   schedule:
-    - cron: '0 23 * * SUN-THU'
+    - cron: '0 23 * * SUN'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}


### PR DESCRIPTION
## Motivation

This PR aims to add scheduled build of docker images. Additionally, it will implement a feature to automatically publish images tagged with `latest` on a daily basis.
Although Optuna V4.5 was released two weeks ago, this repository lacks an automated mechanism to update dependencies, so the `optuna-mcp:latest` image continues to use Optuna V4.4.

## Description of the changes

- Add a `schedule` trigger
- Build and release the `latest` image with the schedule trigger
- Separated the handling of `release` and `pull_request` triggers into distinct steps