### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ You can also run the Optuna MCP server using Docker. Make sure you have Docker i
 }
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/optuna-optuna-mcp).
+
 ## Tools provided by Optuna MCP
 
 The Optuna MCP provides the following tools.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/optuna-optuna-mcp).